### PR TITLE
added cluster_proceed_on_restore_failure flag to nats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ start: image
 	kubectl -n argo-events wait --for=condition=Ready --timeout 60s pod --all
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.46.2
 
 .PHONY: lint
 lint: $(GOPATH)/bin/golangci-lint

--- a/codefresh/codefresh.go
+++ b/codefresh/codefresh.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -175,7 +175,7 @@ func (c *Client) sendJSON(jsonBody []byte, url string) error {
 
 		isStatusOK := res.StatusCode >= 200 && res.StatusCode < 300
 		if !isStatusOK {
-			b, _ := ioutil.ReadAll(res.Body)
+			b, _ := io.ReadAll(res.Body)
 			return errors.Errorf("failed reporting to Codefresh, got response: status code %d and body %s, original request body: %s",
 				res.StatusCode, string(b), string(jsonBody))
 		}

--- a/controllers/eventbus/installer/nats.go
+++ b/controllers/eventbus/installer/nats.go
@@ -547,9 +547,9 @@ streaming {
 // Parameter - secret
 // Example:
 //
-// authorization {
-//   token: "abcd1234"
-// }
+//	authorization {
+//	  token: "abcd1234"
+//	}
 func (i *natsInstaller) buildServerAuthSecret(authStrategy v1alpha1.AuthStrategy, secret string) (*corev1.Secret, error) {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -718,7 +718,7 @@ func (i *natsInstaller) buildStatefulSetSpec(serviceName, configmapName, authSec
 							{Name: "cluster", ContainerPort: clusterPort},
 							{Name: "monitor", ContainerPort: monitorPort},
 						},
-						Command: []string{"/nats-streaming-server", "-sc", "/etc/stan-config/stan.conf"},
+						Command: []string{"/nats-streaming-server", "-sc", "/etc/stan-config/stan.conf", "--cluster_proceed_on_restore_failure"},
 						Env: []corev1.EnvVar{
 							{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
 							{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},


### PR DESCRIPTION
Signed-off-by: Daniel Soifer <daniel.soifer@codefresh.io>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
