### PR TITLE
chore: update Argo workflows version and Go module dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk upgrade && \
     apk add ca-certificates && \
     apk --no-cache add tzdata
 
-ENV ARGO_VERSION=v3.6.2-cap-CR-26293
+ENV ARGO_VERSION=v3.6.7-cap-CR-28355
 
 RUN wget -q https://github.com/codefresh-io/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${ARCH}.gz
 RUN gunzip -f argo-linux-${ARCH}.gz

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ EXECUTABLES = curl docker gzip go
 #  docker image publishing options
 DOCKER_PUSH?=false
 IMAGE_NAMESPACE?=quay.io/codefresh
-VERSION?=v1.9.2-cap-CR-29672
-BASE_VERSION:=v1.9.2-cap-CR-29672
+VERSION?=v1.9.2-cap-CR-29689
+BASE_VERSION:=v1.9.2-cap-CR-29689
 
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Argo Events",
-    "version": "v1.9.2-cap-CR-29672"
+    "version": "v1.9.2-cap-CR-29689"
   },
   "paths": {},
   "definitions": {

--- a/go.mod
+++ b/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/gobuffalo/flect v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,9 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/manifests/base/controller-manager/controller-manager-deployment.yaml
+++ b/manifests/base/controller-manager/controller-manager-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         runAsUser: 9731
       containers:
         - name: controller-manager
-          image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+          image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
           imagePullPolicy: Always
           args:
             - controller
@@ -28,7 +28,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ARGO_EVENTS_IMAGE
-              value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+              value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
           volumeMounts:
             - mountPath: /etc/argo-events
               name: controller-config-volume

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 images:
 - name: quay.io/argoproj/argo-events
   newName: quay.io/codefresh/argo-events
-  newTag: v1.9.2-cap-CR-29672
+  newTag: v1.9.2-cap-CR-29689
 
 patches:
 - patch: |-
@@ -28,4 +28,4 @@ patches:
             - name: controller-manager
               env:
                 - name: ARGO_EVENTS_IMAGE
-                  value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+                  value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689

--- a/manifests/extensions/validating-webhook/events-webhook-deployment.yaml
+++ b/manifests/extensions/validating-webhook/events-webhook-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: webhook
-        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
         imagePullPolicy: Always
         args:
         - webhook-service

--- a/manifests/extensions/validating-webhook/kustomization.yaml
+++ b/manifests/extensions/validating-webhook/kustomization.yaml
@@ -12,4 +12,4 @@ namespace: argo-events
 images:
 - name: quay.io/argoproj/argo-events
   newName: quay.io/codefresh/argo-events
-  newTag: v1.9.2-cap-CR-29672
+  newTag: v1.9.2-cap-CR-29689

--- a/manifests/install-validating-webhook.yaml
+++ b/manifests/install-validating-webhook.yaml
@@ -123,7 +123,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PORT
           value: "443"
-        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
         imagePullPolicy: Always
         name: webhook
       serviceAccountName: argo-events-webhook-sa

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -401,12 +401,12 @@ spec:
         - controller
         env:
         - name: ARGO_EVENTS_IMAGE
-          value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+          value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -322,12 +322,12 @@ spec:
         - --namespaced
         env:
         - name: ARGO_EVENTS_IMAGE
-          value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+          value: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29672
+        image: quay.io/codefresh/argo-events:v1.9.2-cap-CR-29689
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
- Bump ARGO_VERSION from v3.6.2-cap-CR-26293 to v3.6.7-cap-CR-28355 in Dockerfile.
- Update github.com/golang-jwt/jwt/v4 from v4.5.0 to v4.5.2 in go.mod and go.sum.
- Update version references in manifests and configuration files from v1.9.2-cap-CR-29672 to v1.9.2-cap-CR-29689.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
